### PR TITLE
Merge ageLimits

### DIFF
--- a/config.EXAMPLE.json
+++ b/config.EXAMPLE.json
@@ -9,6 +9,7 @@
     "scheme_manager": "irma-demo",
     "idin_issuer": "RU",
     "idin_credential": "idinData",
+    "age_limits_credential_enabled": true,
     "age_limits_credential": "ageLimits",
     "initials_attribute": "initials",
     "lastname_attribute": "familyName",

--- a/src/main/java/org/irmacard/idin/web/IdinConfiguration.java
+++ b/src/main/java/org/irmacard/idin/web/IdinConfiguration.java
@@ -39,6 +39,7 @@ public class IdinConfiguration extends BaseConfiguration {
 	private String scheme_manager = "";
 	private String idin_issuer = "";
 	private String idin_credential = "";
+	private boolean age_limits_credential_enabled = true;
 	private String age_limits_credential = "";
 
 
@@ -282,5 +283,9 @@ public class IdinConfiguration extends BaseConfiguration {
 
 	public String getAgeLimitsCredential() {
 		return age_limits_credential;
+	}
+
+	public boolean isAgeLimitsCredentialEnabled() {
+		return age_limits_credential_enabled;
 	}
 }

--- a/src/main/java/org/irmacard/idin/web/IdinResource.java
+++ b/src/main/java/org/irmacard/idin/web/IdinResource.java
@@ -327,6 +327,9 @@ public class IdinResource {
 			addressLine += "; " + attributes.get(idinSamlAddressExtraKey);
 		}
 
+		int[] ages = {12,16,18,21,65};
+		HashMap<String,String> ageAttrs = ageAttributes(ages, dob);
+
 		//get iDIN data credential
 		HashMap<String,String> attrs = new HashMap<>();
 		attrs.put(IdinConfiguration.getInstance().getInitialsAttribute(), attributes.get(idinSamlInitialsKey));
@@ -340,6 +343,7 @@ public class IdinResource {
 		attrs.put(IdinConfiguration.getInstance().getCityAttribute(), attributes.get(idinSamlCityKey));
 		attrs.put(IdinConfiguration.getInstance().getPostalcodeAttribute(),attributes.get(idinSamlPostalCodeKey));
 		attrs.put(IdinConfiguration.getInstance().getCountryAttribute(), attributes.get(idinSamlCountryKey));
+		attrs.putAll(ageAttrs);
 
 		//add iDIN data credential
 		credentials.put(new CredentialIdentifier(
@@ -348,13 +352,14 @@ public class IdinResource {
 				IdinConfiguration.getInstance().getIdinCredential()
 		), attrs);
 
-		//add age limits credential
-		int[] ages = {12,16,18,21,65};
-		credentials.put(new CredentialIdentifier(
-				IdinConfiguration.getInstance().getSchemeManager(),
-				IdinConfiguration.getInstance().getAgeLimitsIssuer(),
-				IdinConfiguration.getInstance().getAgeLimitsCredential()
-		), ageAttributes(ages, dob));
+		//add age limits credential if enabled
+		if (IdinConfiguration.getInstance().isAgeLimitsCredentialEnabled()) {
+			credentials.put(new CredentialIdentifier(
+					IdinConfiguration.getInstance().getSchemeManager(),
+					IdinConfiguration.getInstance().getAgeLimitsIssuer(),
+					IdinConfiguration.getInstance().getAgeLimitsCredential()
+			), ageAttrs);
+		}
 
 		Calendar calendar = Calendar.getInstance();
 		calendar.add(Calendar.YEAR, 1);


### PR DESCRIPTION
Include the ageLimit attributes in the main iDIN credential instead of having a separate credential with ageLimits, exactly in line with the ageLimits in the `gemeente.personalData` credential.