### PR TITLE
ci: run gradle unit tests in status checks

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -12,6 +12,26 @@ on:
   workflow_dispatch:
 
 jobs:
+    unit-tests:
+      name: Gradle tests
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Set up JDK 21
+          uses: actions/setup-java@v4
+          with:
+            distribution: temurin
+            java-version: '21'
+            cache: gradle
+
+        # The Docker build compiles the app but does not run the JUnit suite;
+        # run it explicitly so unit tests gate every PR.
+        - name: Run unit tests
+          run: ./gradlew --no-daemon clean test
+
     build-docker:
       runs-on: ubuntu-latest
 

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -27,8 +27,10 @@ jobs:
             java-version: '21'
             cache: gradle
 
-        # The Docker build compiles the app but does not run the JUnit suite;
-        # run it explicitly so unit tests gate every PR.
+        # The Dockerfile's javabuild stage already runs the JUnit suite as part
+        # of the build-docker job, so tests are gated either way. This dedicated
+        # job runs them decoupled from the image build for faster feedback,
+        # test reporting, and Gradle dependency caching.
         - name: Run unit tests
           run: ./gradlew --no-daemon clean test
 


### PR DESCRIPTION
The JUnit suite already runs in CI via the Dockerfile's `javabuild` stage (`gradle --no-daemon clean test`, also again through `gradle build`), which executes inside the existing `build-docker` job — so the unit tests were already gated on every PR and push to `master`.

This adds a dedicated **Gradle tests** job to `status-checks.yml` (JDK 21 / temurin, gradle wrapper) that runs `./gradlew --no-daemon clean test` directly. Running it decoupled from the Docker image build gives faster feedback, standalone test reporting, and Gradle dependency caching. It does duplicate the test run that already happens inside the image build (~2× test cost) — an accepted trade-off for the faster, clearer signal.

(Originally intended for #48's branch, but #48 was already merged — hence this standalone PR.)